### PR TITLE
Fixed theme option text extending beyond popup

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -115,7 +115,6 @@ body {
 #themePopup {
   z-index: 10;
   height: 384px;
-  width: 20%;
   margin-bottom: 150px;
   border-radius: 5px;
   background-color: var(--text-color);

--- a/styles/style.css
+++ b/styles/style.css
@@ -125,8 +125,8 @@ body {
   font-size: 2rem;
   cursor: pointer;
   border-radius: 3px;
-  padding: 10px 10px 10px 10px;
-  margin: 5px 5px 5px 5px;
+  padding: 10px;
+  margin: 5px;
   text-align: center;
 }
 


### PR DESCRIPTION
Deleted popup explicit size so it now resizes to fit theme text on smaller screens.

Closes [#57]