### PR TITLE
Added horizontal padding to popup buttons

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -129,7 +129,7 @@ body {
   font-size: 2rem;
   cursor: pointer;
   border-radius: 3px;
-  padding: 10px;
+  padding: 10px 25px;
   margin: 5px;
   text-align: center;
 }
@@ -182,6 +182,7 @@ body {
   background-color: #121520;
   color: #fff;
 }
+
 
 @keyframes rgb {
   0% {


### PR DESCRIPTION
Added 25px of horizontal padding to theme buttons to return it (close) to original proportions. 

Tell me what you think:

<img width="513" alt="Screen Shot 2022-07-16 at 6 50 08 PM" src="https://user-images.githubusercontent.com/109128466/179379543-2842152f-05f8-4baf-a889-c59addad2b55.png">

Closes #69 