### PR TITLE
fix: align content vertically

### DIFF
--- a/rungeon.html
+++ b/rungeon.html
@@ -32,7 +32,7 @@
 
   <body>
   <!--Navigation bar-->
-  <nav class="navbar navbar-expand-lg">
+  <nav class="navbar navbar-expand-lg" id="navbar">
       <div class="container-fluid">
           <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNavDropdown" aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle navigation">
               <span class="navbar-toggler-icon"></span>

--- a/styles/style.css
+++ b/styles/style.css
@@ -205,6 +205,12 @@ body {
   background-color: var(--nav-color) !important;
 }
 
+/* This id is important to override Bootstrap */
+#navbar {
+  position: absolute;
+  width: 100%;
+}
+
 #navbarNavDropdown {
   text-align: center;
   justify-content: center;


### PR DESCRIPTION
Okay, I've aligned the content vertically by making the navbar position absolute instead of relative. This does mean that I had to override Bootstrap with an id. 

Closes #67 

The content doesn't need to be horizontally aligned. In your previous image, you were comparing the center of the content with the center of the navbar buttons. The actual center of the navbar includes the little drop-down arrow.

![Screen Shot 2022-07-17 at 12 18 05 PM](https://user-images.githubusercontent.com/109128466/179419970-8b902172-421c-463e-9a44-f352b9a17114.png)

So while It may look off center, in the code it's doing what it should.

![Screen Shot 2022-07-17 at 12 37 27 PM](https://user-images.githubusercontent.com/109128466/179420285-4dc0db6d-6b72-4082-9be4-1b0fd0f9a21f.png)

I can try to shift the navbar over if you want it more aesthetically pleasing. 😃 