### PR TITLE
Fixed navbar dropdown error

### DIFF
--- a/main.js
+++ b/main.js
@@ -151,7 +151,11 @@ function setTheme(event) {
   localStorage.setItem("theme", `${event.target.id}`);
   document.getElementById(event.target.id).innerHTML +=
     ' <i class="fa-solid fa-check"></i>';
+  
+  //Only toggle the main theme popup when on index.html (the navbar dropdown has a close of its own)
+  if(window.location.pathname == '/' || window.location.pathname == '/index.html'){
     toggleThemePopup();
+  }
 }
 
 


### PR DESCRIPTION
Fixed an error caused by selecting an option in the navbar dropdown. 
<img width="401" alt="Screen Shot 2022-07-18 at 2 20 32 AM" src="https://user-images.githubusercontent.com/109128466/179472224-a36c0a8e-e2e6-4bad-be97-22f39cb0f61c.png">

The setTheme function (which also toggles the popup) was originally intended to be used only on index.html where the popup exists. Added a check to make sure that the page is on index.html so it can find the popup. 

The navbar dropdown has a close function of its own (through bootstrap I think) so this fix shouldn't change anything but remove the error. 
