### PR TITLE
theme pop-up

### DIFF
--- a/main.js
+++ b/main.js
@@ -143,7 +143,8 @@ function addPopupListener() {
 function setTheme(event) {
   try {
     let previousTheme = localStorage.getItem("theme");
-    document.getElementById(previousTheme).innerHTML = previousTheme; 
+    document.getElementById(previousTheme).innerHTML = previousTheme;
+    toggleThemePopup();
   } catch (error) {
     getThemes();
   }

--- a/main.js
+++ b/main.js
@@ -156,11 +156,6 @@ function setTheme(event) {
   localStorage.setItem("theme", `${event.target.id}`);
   document.getElementById(event.target.id).innerHTML +=
     ' <i class="fa-solid fa-check"></i>';
-  
-  //Only toggle the main theme popup when on index.html (the navbar dropdown has a close of its own)
-  if(window.location.pathname == '/' || window.location.pathname == '/index.html'){
-    toggleThemePopup();
-  }
 }
 
 


### PR DESCRIPTION
### Description
When clicking a theme the pop-up close.
## Changes
1- Call toggleThemePopup in the setTheme function so when clicking a theme the pop-up close.
2- Remove the if statement that only remove de popup if has in the / or /index.html location.

## Solves
Issue: https://github.com/devkennyy/rungeon/issues/95
