### PR TITLE
#117 theme popup onclick

### DIFF
--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -1,14 +1,5 @@
 window.onload = runStageRequiredScripts();
 
-//themeToggler ensures that it needs two clicks on body to close the themePopup, given that a click on the button that opens the popup counts as a click on body as well
-var themeToggler = 0;
-document.addEventListener('click', function (event) {
-  themeToggler++;
-  if((themeToggler & 2) === 0) {
-    document.getElementById('themePopup').style.display = 'none';
-    document.getElementById('doors_icon').style.visibility = 'visible';
-  }
-});
 
 //Global vars
 const totalStages = 4;
@@ -143,7 +134,7 @@ function addPopupListener() {
 
   window.addEventListener('click', function (e) {
 
-    if (document.getElementById('themePopup').hidden) {return;}
+    if (document.getElementById('themePopup').style.display == 'none') {return;}
 
     if (e.target == document.body) {
       toggleThemePopup();

--- a/public/scripts/themes.js
+++ b/public/scripts/themes.js
@@ -47,6 +47,8 @@ const setTheme = (theme) => {
   }
 
   getTheme(currTheme);
+
+  toggleThemePopup()
 };
 
 const getTheme = (oldTheme) => {


### PR DESCRIPTION
### Description

Okay. Removed some of the changes made in PR #104 because they were already implemented in #78. 
(#104 also brought back the error referenced in #93)

Fixed bug where the popup would open when the body is clicked. The click handler was not up to date with the new CSS-only popup hiding. 

Re-added the line ```toggleThemePopup()``` that was lost when themes.js was created. 

## Changes

Removed redundancy.
Fixed the popup bug.
Re-added popup toggling when the theme is changed.

## Solves

Closes [#117]
