### PR TITLE
Sets theme in localStorage if none

### DIFF
--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -25,6 +25,11 @@ function runStageRequiredScripts() {
     //Add listener to close theme popup when clicked outside
     addPopupListener();
   }
+
+  //Set theme in localStorage if it doesn't exist
+  if (localStorage.getItem("theme") == null){
+    localStorage.setItem("theme", 'default');
+  }
 }
 
 function toggleThemePopup() {


### PR DESCRIPTION
### Description

Fixed a bug for new users where the screen would be white because no theme was set in localStorage.

## Changes

* Sets theme in localStorage to "default" if none exists

## Solves

Solves #154

Maybe solves #120?
(I'm fairly sure it's the same issue)
